### PR TITLE
fix: cannot install npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "publishVersion": "yarn test && yarn build && yarn lint && yarn publish",
     "test": "jest",
     "lint": "yarn eslint src/**/*",
-    "postinstall": "husky install"
+    "prepare": "husky install"
   },
   "peerDependencies": {
     "react": ">=16.8",


### PR DESCRIPTION
Closes #15

To not trigger `postinstall` hook if the library is installed from npm, other libraries (e.g. [webpack](https://github.com/webpack/webpack/blob/master/package.json#L157)) use a `prepare` script instead of `postinstall`.